### PR TITLE
Add build and publish dry run when drafting new release

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -7,6 +7,16 @@ on:
         description: 'The new version in major.minor.patch format.'
         required: true
         type: string
+      build:
+        description: 'Build the projet with cargo, useful when Cargo.lock is commited and needs to be updated.'
+        required: false
+        default: false
+        type: boolean
+      check_publish:
+        description: 'Dry run cargo publish before pushing changes, useful to not allow unpublishable releases.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   draft-new-release:
@@ -30,10 +40,24 @@ jobs:
           version: ${{ github.event.inputs.version }}
           manifest: Cargo.toml
 
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+            default: true
+            override: true
+
+      - name: Cargo build update lockfile
+        if: ${{ inputs.build }}
+        run: cargo build
+
       - name: Format CHANGELOG
         run: |
           curl -fsSL https://dprint.dev/install.sh | sh
           /home/runner/.dprint/bin/dprint fmt CHANGELOG.md
+
+      - name: Publish dry run
+        if: ${{ inputs.check_publish }}
+        run: cargo publish --dry-run --allow-dirty
 
       - name: Add, Commit & Push
         id: make-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New input `build` for `draft-new-release.yml` to build the crate before add & commit the files, allows lockfile update
+- New input `check_publish` for `draft-new-release.yml` to dry run the cargo publish before add & commit the files, allows to not open a PR on unpublishable state.
+
 ## [1.0.2] - 2021-11-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find an example of usage for the following shared workflows.
 
 `draft-new-release.yml` prepare the creation of a new release by creating a new branch `release/{version}` and opening a pull request targeting `main`.
 
-**The changelog is updated to `{version}` and today's date. `Cargo.toml` version is updated to `{version}` and `Cargo.toml` is updated if input `build` is set to true. Set input `check_publish` to dry run publish**.
+**The changelog is updated to `{version}` and today's date. `Cargo.toml` version is updated to `{version}` and `Cargo.toml` is updated if input `build` (default false) is set to true. Set input `check_publish` (default false) to dry run publish**.
 
 > Version should follow semantic versioning.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ You can find an example of usage for the following shared workflows.
 
 ### Draft new release
 
-`draft-new-release.yml` prepare the creation of a new release by creating a new branch `release/{version}` and opening a pull request targeting `main`. **The changelog is updated with the `{version}` parameter and today's date and the `Cargo.toml` version is updated with the new `{version}`**. Version should follow semantic versioning.
+`draft-new-release.yml` prepare the creation of a new release by creating a new branch `release/{version}` and opening a pull request targeting `main`.
+
+**The changelog is updated to `{version}` and today's date. `Cargo.toml` version is updated to `{version}` and `Cargo.toml` is updated if input `build` is set to true. Set input `check_publish` to dry run publish**.
+
+> Version should follow semantic versioning.
 
 The commit will be associated with GitHub Actions bot.
 
@@ -33,6 +37,8 @@ jobs:
     uses: farcaster-project/workflows/.github/workflows/draft-new-release.yml@v1.0.2
     with:
       version: ${{ github.event.inputs.version }}
+      build: false
+      check_publish: true
 ```
 
 ### Create release


### PR DESCRIPTION
When drafting a release:

- when releasing the node we need a way to update the `Cargo.lock` (with cargo build) because its a tracked file
- adding the possibility to run `cargo publish --dry-run` to not draft release unpublishable to crates.io (useful for core) 